### PR TITLE
fix #20: Avoid emitting 'Function'

### DIFF
--- a/packages/typewiz-node/yarn.lock
+++ b/packages/typewiz-node/yarn.lock
@@ -193,9 +193,9 @@ typescript@^2.4.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.6.2.tgz#3c5b6fd7f6de0914269027f03c0946758f7673a4"
 
-typewiz@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/typewiz/-/typewiz-0.4.0.tgz#d55dc79fe0a7277a460e3ea1d6b1062a72b9fd54"
+typewiz@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/typewiz/-/typewiz-0.5.0.tgz#1a8bfdc41d6bb0b52a772fbc949efdcb8dd07702"
   dependencies:
     typescript "^2.4.2"
 

--- a/src/type-collector-snippet.spec.ts
+++ b/src/type-collector-snippet.spec.ts
@@ -46,15 +46,96 @@ describe('type-collector', () => {
         it('should return "object" for Objects', () => {
             expect($_$twiz.typeName({})).toBe('object');
         });
-
-        it('should return "Function" for functions', () => {
-            expect($_$twiz.typeName(() => 0)).toBe('Function');
-        });
-
         it('should throw a NestError in case of array has includes itself', () => {
-            const a = [];
+            const a: any[] = [];
             a.push(a);
             expect(() => $_$twiz.typeName(a)).toThrowError('NestError');
+        });
+
+        describe('functions', () => {
+            /* tslint:disable:only-arrow-functions*/
+            it('should return "() => any" for functions without arguments', () => {
+                const expected = '() => any';
+
+                /* tslint:disable-next-line*/
+                expect($_$twiz.typeName(() => 0)).toBe(expected);
+                expect(
+                    $_$twiz.typeName(function() {
+                        return 0;
+                    }),
+                ).toBe(expected);
+            });
+
+            it('should return "(a: any, b: any) => any" for functions with arguments', () => {
+                const expected = '(a: any,b: any) => any';
+
+                expect($_$twiz.typeName((a: any, b: any) => a + b)).toBe(expected);
+                expect(
+                    $_$twiz.typeName(function(a: any, b: any) {
+                        return a * b;
+                    }),
+                ).toBe(expected);
+            });
+
+            it('should return "(a: any, b: any) => any" for functions with default value', () => {
+                const expected = '(a: any,b: any) => any';
+
+                expect($_$twiz.typeName((a = 2, b = 3) => a + b)).toBe(expected);
+                expect(
+                    $_$twiz.typeName(function(a = '2', b = 3) {
+                        return a + b;
+                    }),
+                ).toBe(expected);
+            });
+
+            it('should return "(a: any) => any" for functions with array destructor', () => {
+                const expected = '(aArray: any) => any';
+
+                expect($_$twiz.typeName(([a]: number[]) => a)).toBe(expected);
+                expect(
+                    $_$twiz.typeName(function([a]: number[]) {
+                        return a;
+                    }),
+                ).toBe(expected);
+            });
+
+            it('should return "(aObject: {a: any}) => any" for functions with object destructor', () => {
+                expect($_$twiz.typeName(({ a }: { a: number }) => a)).toBe('(aObject: {a: any}) => any');
+                expect(
+                    $_$twiz.typeName(function({ a }: { a: number }) {
+                        return a;
+                    }),
+                ).toBe('(aObject: {a: any}) => any');
+            });
+
+            it('should return "(a: any[]) => any" for functions with rest operator', () => {
+                const expected = '(...aArray: any[]) => any';
+
+                expect($_$twiz.typeName((...a: number[]) => a)).toBe(expected);
+                expect(
+                    $_$twiz.typeName(function(...a: number[]) {
+                        return a;
+                    }),
+                ).toBe(expected);
+            });
+
+            it('should work for a complex function', () => {
+                const multByNumberHOC = (multiplier: number) => (num: number) => num * multiplier;
+                expect($_$twiz.typeName(multByNumberHOC)).toBe('(multiplier: any) => any');
+
+                const multBy2 = multByNumberHOC(2);
+                expect($_$twiz.typeName(multBy2)).toBe('(num: any) => any');
+
+                function stringify(json: {}, stringifyFunc = JSON.stringify, replacer = null, space = ' ') {
+                    return stringifyFunc(json, replacer, space);
+                }
+
+                expect($_$twiz.typeName(stringify)).toBe(
+                    '(json: any,stringifyFunc: any,replacer: any,space: any) => any',
+                );
+            });
+
+            /* tslint:enable:only-arrow-functions*/
         });
     });
 });

--- a/src/type-collector-snippet.ts
+++ b/src/type-collector-snippet.ts
@@ -26,10 +26,49 @@ export function getTypeName(value: any, nest = 0): string | null {
         }
         return `Array<${itemTypes.sort().join('|')}>`;
     }
+    if (value instanceof Function) {
+        let argsStr: string = value.toString().split('=>')[0];
+
+        // make sure argsStr is in a form of (arg1,arg2) for the following cases
+        // fn = a => 3
+        // fn = (a) => 3
+        // function fn(a) { return 3 }
+
+        argsStr = argsStr.includes('(') ? (argsStr.match(/\(.*?\)/gi) || '()')[0] : `(${argsStr})`;
+        const args: string[] = argsStr
+            .replace(/[()]/g, '')
+            .split(',')
+            .filter((e: string) => e !== '');
+
+        const typedArgs = args.map((arg) => {
+            let [name] = arg.split('=');
+            name = name.trim();
+
+            if (name.includes('[')) {
+                const nakedName = name.replace(/\[|\]/gi, '').trim();
+                name = `${nakedName}Array`;
+                return `${name}: any`;
+            }
+            if (name.includes('{')) {
+                const nakedName = name.replace(/\{|\}/gi, '').trim();
+                name = `${nakedName}Object: {${nakedName}: any}`;
+                return `${name}`;
+            }
+            if (name.includes('...')) {
+                name = `${name}Array: any[]`;
+                return `${name}`;
+            }
+
+            return `${name}: any`;
+        });
+
+        return `(${typedArgs}) => any`;
+    }
     if (value.constructor && value.constructor.name) {
         const { name } = value.constructor;
         return name === 'Object' ? 'object' : name;
     }
+
     return typeof value;
 }
 


### PR DESCRIPTION
fixing #20  for the following cases

fn = () => a
fn = (a = 5) => a
fn = ({a}) => a
fn = ([a]) => a
fn = (...args) => args[0]