### PR TITLE
Find more types using Type Inference

### DIFF
--- a/src/apply-types.spec.ts
+++ b/src/apply-types.spec.ts
@@ -1,0 +1,32 @@
+import * as ts from 'typescript';
+import { applyTypes } from './apply-types';
+
+describe('applyTypes', () => {
+    it('should throw an error if given non-existing tsconfig.json file', () => {
+        expect(() => applyTypes([], { tsConfig: 'not-found-file.json' })).toThrowError(
+            `Error while reading not-found-file.json: The specified path does not exist: 'not-found-file.json'.`,
+        );
+    });
+
+    it('should throw an error if given bad tsconfig.json file', () => {
+        const tsConfigHost = {
+            ...ts.sys,
+            readFile: jest.fn(() => '<invalid json>'),
+        };
+        expect(() => applyTypes([], { tsConfig: 'tsconfig.bad.json', tsConfigHost })).toThrowError(
+            `Error while reading tsconfig.bad.json: '{' expected.`,
+        );
+        expect(tsConfigHost.readFile).toHaveBeenCalledWith('tsconfig.bad.json');
+    });
+
+    it('should throw an error in case of validation errors in given tsconfig.json file', () => {
+        const tsConfigHost = {
+            ...ts.sys,
+            readFile: jest.fn(() => '{ "include": 123 }'),
+        };
+        expect(() => applyTypes([], { tsConfig: 'tsconfig.invalid.json', tsConfigHost })).toThrowError(
+            `Error while parsing tsconfig.invalid.json: Compiler option 'include' requires a value of type Array.`,
+        );
+        expect(tsConfigHost.readFile).toHaveBeenCalledWith('tsconfig.invalid.json');
+    });
+});

--- a/src/apply-types.ts
+++ b/src/apply-types.ts
@@ -1,10 +1,14 @@
 import * as fs from 'fs';
 import * as path from 'path';
+import * as ts from 'typescript';
 
 import { IExtraOptions } from './instrument';
 import { applyReplacements, Replacement } from './replacement';
+import { ISourceLocation } from './type-collector-snippet';
 
-export type ICollectedTypeInfo = Array<[string, number, string[], IExtraOptions]>;
+export type ICollectedTypeInfo = Array<
+    [string, number, Array<[string | undefined, ISourceLocation | undefined]>, IExtraOptions]
+>;
 
 export interface IApplyTypesOptions {
     /**
@@ -18,20 +22,60 @@ export interface IApplyTypesOptions {
      * If given, all the file paths in the collected type info will be resolved relative to this directory.
      */
     rootDir?: string;
+
+    /**
+     * Path to your project's tsconfig file
+     */
+    tsConfig?: string;
+
+    // You probably never need to touch these two - they are used by the integration tests to setup
+    // a virtual file system for TS:
+    tsConfigHost?: ts.ParseConfigHost;
+    tsCompilerHost?: ts.CompilerHost;
 }
 
-export function applyTypesToFile(source: string, typeInfo: ICollectedTypeInfo, options: IApplyTypesOptions) {
+function findType(program?: ts.Program, typeName?: string, sourcePos?: ISourceLocation) {
+    if (program && sourcePos) {
+        const [sourceName, sourceOffset] = sourcePos;
+        const typeChecker = program.getTypeChecker();
+        let foundType: string | null = null;
+        function visit(node: ts.Node) {
+            if (node.getStart() === sourceOffset) {
+                const type = typeChecker.getTypeAtLocation(node);
+                foundType = typeChecker.typeToString(type);
+            }
+            ts.forEachChild(node, visit);
+        }
+        const sourceFile = program.getSourceFile(sourceName);
+        visit(sourceFile);
+        if (foundType) {
+            return foundType;
+        }
+    }
+    return typeName;
+}
+
+export function applyTypesToFile(
+    source: string,
+    typeInfo: ICollectedTypeInfo,
+    options: IApplyTypesOptions,
+    program?: ts.Program,
+) {
     const replacements = [];
     const prefix = options.prefix || '';
     for (const [, pos, types, opts] of typeInfo) {
         const isOptional = source[pos - 1] === '?';
-        let sortedTypes = types.sort();
+        let sortedTypes = types
+            .map(([name, sourcePos]) => findType(program, name, sourcePos))
+            .filter((t) => t)
+            .sort();
         if (isOptional) {
             sortedTypes = sortedTypes.filter((t) => t !== 'undefined');
-            if (sortedTypes.length === 0) {
-                continue;
-            }
         }
+        if (sortedTypes.length === 0) {
+            continue;
+        }
+
         let suffix = '';
         if (opts && opts.parens) {
             replacements.push(Replacement.insert(opts.parens[0], '('));
@@ -44,6 +88,22 @@ export function applyTypesToFile(source: string, typeInfo: ICollectedTypeInfo, o
 
 export function applyTypes(typeInfo: ICollectedTypeInfo, options: IApplyTypesOptions = {}) {
     const files: { [key: string]: typeof typeInfo } = {};
+    let program: ts.Program | undefined;
+    if (options.tsConfig) {
+        const configHost = options.tsConfigHost || ts.sys;
+        const { config, error } = ts.readConfigFile(options.tsConfig, configHost.readFile);
+        if (error) {
+            throw new Error(`Error while reading ${options.tsConfig}: ${error.messageText}`);
+        }
+
+        const parsed = ts.parseJsonConfigFileContent(config, configHost, options.rootDir || '');
+        if (parsed.errors.length) {
+            const errors = parsed.errors.map((e) => e.messageText).join(', ');
+            throw new Error(`Error while parsing ${options.tsConfig}: ${errors}`);
+        }
+
+        program = ts.createProgram(parsed.fileNames, parsed.options, options.tsCompilerHost);
+    }
     for (const entry of typeInfo) {
         const file = entry[0];
         if (!files[file]) {
@@ -54,6 +114,6 @@ export function applyTypes(typeInfo: ICollectedTypeInfo, options: IApplyTypesOpt
     for (const file of Object.keys(files)) {
         const filePath = options.rootDir ? path.join(options.rootDir, file) : file;
         const source = fs.readFileSync(filePath, 'utf-8');
-        fs.writeFileSync(filePath, applyTypesToFile(source, files[file], options));
+        fs.writeFileSync(filePath, applyTypesToFile(source, files[file], options, program));
     }
 }

--- a/src/replacement.ts
+++ b/src/replacement.ts
@@ -1,17 +1,22 @@
 export class Replacement {
-    public static insert(pos: number, text: string) {
-        return new Replacement(pos, pos, text);
+    public static insert(pos: number, text: string, priority = 0) {
+        return new Replacement(pos, pos, text, priority);
     }
 
     public static delete(start: number, end: number) {
         return new Replacement(start, end, '');
     }
 
-    constructor(readonly start: number, readonly end: number, readonly text = '') {}
+    constructor(readonly start: number, readonly end: number, readonly text = '', readonly priority = 0) {}
 }
 
 export function applyReplacements(source: string, replacements: Replacement[]) {
-    replacements = replacements.sort((r1, r2) => (r2.end !== r1.end ? r2.end - r1.end : r2.start - r1.start));
+    replacements = replacements.sort(
+        (r1, r2) =>
+            r2.end !== r1.end
+                ? r2.end - r1.end
+                : r1.start !== r2.start ? r2.start - r1.start : r1.priority - r2.priority,
+    );
     for (const replacement of replacements) {
         source = source.slice(0, replacement.start) + replacement.text + source.slice(replacement.end);
     }


### PR DESCRIPTION
Many times, TypeScript can infer the types of arguments you pass in a function call by looking at their definition. Consider the following example:

```typescript
const promise = Promise.resolve(15);
f(promise);
```

In this case, TypeScript can infer the type of `promise` as `Promise<number>`. We can take advantage of this information to add type information to the first parameter of `f`.  So given the following code as input:

```typescript
function f(a) {
  return a;
}

const promise = Promise.resolve(15);
f(promise);
```

We should be able to discover the type of argument `a` correctly, and get the following result:

```typescript
function f(a: Promise<number>) {
  return a;
}

const promise = Promise.resolve(15);
f(promise);
```

This PR adds experimental support for this feature. At this time, the code is still work-in-progress and is not yet ready to be merged.